### PR TITLE
Modernize to latest versions supported by Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.47</version>
+        <version>4.51</version>
+        <relativePath/>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>commons-lang-api</artifactId>
@@ -12,7 +13,7 @@
     <packaging>hpi</packaging>
     <properties>
         <commons-lang.version>2.6</commons-lang.version>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
     </properties>
     <name>commons-lang v2.x Jenkins Api Plugin</name>
     <description>Jenkins Api Plugin to provide commons-lang:commons-lang:${commons-lang.version}.


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin closer to the [recommended Jenkins baseline version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) without making the change too big. If this goes well, I can follow up with a subsequent PR to modernize further.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePluginForJava8